### PR TITLE
fix: bump consola to 3.x to align with other nuxt 2 packages

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,3 +1,3 @@
-const consola = require('consola')
+const { consola } = require('consola')
 
-module.exports = consola.withScope('nuxt:stylelint')
+module.exports = consola.withTag('nuxt:stylelint')

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "yarn lint && jest"
   },
   "dependencies": {
-    "consola": "^2.15.3",
+    "consola": "^3.2.3",
     "stylelint-webpack-plugin": "^2.5.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3370,9 +3370,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001464:
-  version "1.0.30001464"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001464.tgz#888922718df48ce5e33dcfe1a2af7d42676c5eb7"
-  integrity sha512-oww27MtUmusatpRpCGSOneQk2/l5czXANDSFvsc7VuOQ86s3ANhZetpwXNf1zY/zdfP63Xvjz325DAdAoES13g==
+  version "1.0.30001562"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz"
+  integrity sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -3707,6 +3707,11 @@ consola@^2.15.0, consola@^2.15.3, consola@^2.6.0:
   version "2.15.3"
   resolved "https://registry.yarnpkg.com/consola/-/consola-2.15.3.tgz#2e11f98d6a4be71ff72e0bdf07bd23e12cb61550"
   integrity sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==
+
+consola@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/consola/-/consola-3.2.3.tgz#0741857aa88cfa0d6fd53f1cff0375136e98502f"
+  integrity sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==
 
 console-browserify@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
Addressing the https://github.com/nuxt/nuxt/issues/24343 issue which is about outdated `consola` being used in a couple of Nuxt 2 packages.