### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ npm install -D stylelint
 With `pnpm`
 
 ```bash
-pnpm add -D @nuxtjs/stylelint-module
+npx nuxi@latest module add stylelint
 ```
 
 Or, with `yarn`
 
 ```bash
-yarn add -D @nuxtjs/stylelint-module
+npx nuxi@latest module add stylelint
 ```
 
 Or, with `npm`
 
 ```bash
-npm install -D @nuxtjs/stylelint-module
+npx nuxi@latest module add stylelint
 ```
 
 2. Add `@nuxtjs/stylelint-module` to the `modules` section of `nuxt.config.js`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
